### PR TITLE
Add step to setup Python

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+
     - name: Install dependencies
       shell: bash
       run: |


### PR DESCRIPTION
Precaution (CLI) requires Python 3.12, so add step to install it.